### PR TITLE
fix: background attribute should not require replacement

### DIFF
--- a/internal/provider/index_resource.go
+++ b/internal/provider/index_resource.go
@@ -185,9 +185,6 @@ func (r *indexResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			"background": schema.BoolAttribute{
 				Description: "Create the index in the background.",
 				Optional:    true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(),
-				},
 			},
 			"collation": schema.SingleNestedAttribute{
 				Description: "Index collation.",


### PR DESCRIPTION
Background should not trigger replacement because once the index is created this attribute won't change anything